### PR TITLE
chore(): add logging

### DIFF
--- a/docker/ogcio/oidc-auth-hook.js
+++ b/docker/ogcio/oidc-auth-hook.js
@@ -24,6 +24,18 @@ function enableOidcOauth(app, config, services) {
   const { baseUriPath } = config.server;
   const { userService } = services;
 
+  console.log('Initializing OIDC authentication');
+  console.dir({
+    issuer: `${AUTH_HOST}/oidc`,
+    authorizationURL: `${AUTH_HOST}/oidc/auth`,
+    tokenURL: `${AUTH_HOST}/oidc/token`,
+    userInfoURL: `${AUTH_HOST}/oidc/me`,
+    callbackURL: `${contextPath}/api/auth/callback`,
+    clientID: AUTH_APP_ID,
+    clientSecret: AUTH_APP_SECRET,
+    scope: ["profile", "offline_access", "email"],
+  });
+
   passport.use(
     "oidc",
     new OpenIDConnectStrategy(
@@ -47,7 +59,9 @@ function enableOidcOauth(app, config, services) {
     ),
   );
 
-  // app.use(passport.initialize());
+  console.log('Setting up passport middleware');
+  // Make sure to initialize passport AFTER express-session is set up
+  app.use(passport.initialize());
   app.use(passport.session());
 
   passport.serializeUser((user, done) => done(null, user));


### PR DESCRIPTION
Add logging to debug startup issue:

```
[2025-03-07T06:43:12.064] [ERROR] /debug-error-handler.ts - Server failed executing request: {} Error: Login sessions require session support. Did you forget to use `express-session` middleware?
    at SessionStrategy.authenticate (/unleash/node_modules/passport/lib/strategies/session.js:97:41)
    at attempt (/unleash/node_modules/passport/lib/middleware/authenticate.js:378:16)
    at authenticate (/unleash/node_modules/passport/lib/middleware/authenticate.js:379:7)
    at Layer.handle [as handle_request] (/unleash/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/unleash/node_modules/express/lib/router/index.js:328:13)
    at /unleash/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/unleash/node_modules/express/lib/router/index.js:346:12)
    at next (/unleash/node_modules/express/lib/router/index.js:280:10)
    at initialize (/unleash/node_modules/passport/lib/middleware/initialize.js:98:5)
    at Layer.handle [as handle_request] (/unleash/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/unleash/node_modules/express/lib/router/index.js:328:13)
    at /unleash/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/unleash/node_modules/express/lib/router/index.js:346:12)
    at next (/unleash/node_modules/express/lib/router/index.js:280:10)
    at /unleash/node_modules/router/index.js:688:15
    at next (/unleash/node_modules/router/index.js:281:14)
```